### PR TITLE
Fix Failed Build Using Updates to ResearchKit

### DIFF
--- a/NAMS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NAMS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "7874c1b48cbffd086ce8a052c4be873a78613775",
-        "version" : "9.2.3"
+        "revision" : "98a00258d4518b7521253a70b7f70bb76d2120fe",
+        "version" : "9.2.4"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "871d43135925cde39ef7421d8723ce47edfdcc39",
-        "version" : "7.11.1"
+        "revision" : "6039a55afc03aac62e898aea4acdbe20d383978c",
+        "version" : "7.11.2"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/ResearchKit",
       "state" : {
-        "revision" : "3ea06dcc596bd49571ae3353c9c1555776114072",
-        "version" : "2.2.9"
+        "revision" : "f677e4adc38d8ce2bdc718cd420c60d7be45a648",
+        "version" : "2.2.10"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziContact.git",
       "state" : {
-        "revision" : "287bfbc61c7d9c8963282db0e967635b4c54c910",
-        "version" : "0.3.1"
+        "revision" : "03034b813b8f97128209cfe7b4fc6fa1a904f9ab",
+        "version" : "0.3.2"
       }
     },
     {
@@ -230,8 +230,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTestExtensions.git",
       "state" : {
-        "revision" : "edaf9c92c5c0b363058c6cc12bd6116fe843c2e3",
-        "version" : "0.4.3"
+        "revision" : "da65dfa343ef6bf041b2c322448c9d5e1a0bdaa9",
+        "version" : "0.4.4"
       }
     },
     {


### PR DESCRIPTION
# Fix Failed Build Using Updates to ResearchKit

## :recycle: Current situation & Problem
- Builds fail due to a missing `CFBundleVersion` in ResearchKit: https://github.com/StanfordBDHG/NAMS/actions/runs/5358248972/jobs/9732017815
- Fixed the issue in [StanfordBDHG/ResearchKit - 2.2.10](https://github.com/StanfordBDHG/ResearchKit/releases/tag/2.2.10)
- Documented fix and issue in https://github.com/StanfordBDHG/ResearchKit/issues/5

## :bulb: Proposed solution
- Update dependencies to [StanfordBDHG/ResearchKit - 2.2.10](https://github.com/StanfordBDHG/ResearchKit/releases/tag/2.2.10)

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

